### PR TITLE
MiMA Apply Stratospheric Heating Perturbations

### DIFF
--- a/input/CTRLnamelist.nml
+++ b/input/CTRLnamelist.nml
@@ -1,0 +1,221 @@
+&coupler_nml
+   days   = 360,
+   dt_atmos =500,
+   current_date = 0001,1,1,0,0,0
+   calendar = 'thirty_day' /
+
+# Note: damping_order = 4 specifies del 8'th diffusion
+ &spectral_dynamics_nml
+    damping_option          = 'resolution_dependent',
+    damping_order           = 4,
+    do_mass_correction      =.true.,
+    do_energy_correction    =.true., 
+    do_water_correction     =.true.,  
+    water_correction_limit  = 200.e2,
+    initial_sphum           = 2.e-06,  
+    use_virtual_temperature =.false., 
+    vert_advect_uv          = 'second_centered',
+    vert_advect_t           = 'second_centered',
+    use_implicit            = .true.,
+    longitude_origin        = 0.,
+    robert_coeff            = .03,
+    alpha_implicit          = .5,
+    reference_sea_level_press=1.e5,
+    lon_max                 = 128,
+    lat_max                 = 64,
+    num_levels              = 40,
+    num_fourier             = 42,
+    num_spherical           = 43,
+    fourier_inc             = 1,
+    triang_trunc            =.true.,
+    topography_option       = 'interpolated',
+    ocean_topog_smoothing = 0.995,
+    vert_coord_option       = 'uneven_sigma',
+    surf_res                = 0.1,
+    scale_heights           = 7.9,
+    exponent                = 1.4 /
+
+
+# Empty namelist causes all values to take on default values.
+
+ &spectral_init_cont_nml
+    initial_temperature = 264. /
+
+---------- physics namelists --------------
+
+ &rrtm_radiation_nml
+     h2o_lower_limit        = 2.e-07,
+     co2ppmv                = 390.,
+     do_read_ozone          = .true.,
+     ozone_file             = 'ozone_1990',
+     dt_rad_avg             =  4500,
+     dt_rad                 =  4500,
+     lonstep                = 4 /
+
+ &astro_nml
+     solr_cnst   = 1370. /
+
+ &simple_surface_nml
+     do_qflux         = .true.,
+     surface_choice   = 1,
+     Tm               = 285.,
+     heat_capacity    = 3.e08,
+     land_capacity    = 1.e07,
+     trop_capacity    = 1.e08,
+     trop_cap_limit   = 20.
+     const_albedo     = 0.23,
+     albedo_choice    = 7,
+     albedo_wdth      = 5,
+     higher_albedo    = 0.80,
+     albedo_cntrNH    =  68.,
+     albedo_cntrSH    =  64.,
+     lat_glacier      = -70,
+     land_option      = 'interpolated',
+     do_warmpool = .true.,
+     roughness_choice = 4,
+     mom_roughness_land = 5.e3,
+     q_roughness_land = 1.e-12  /   
+#e-17 gives good results
+
+&qflux_nml
+     qflux_amp        = 26.,
+      warmpool_localization_choice = 3,
+     warmpool_k       = 1.66666, 
+     warmpool_amp     = 18., 
+     warmpool_width   = 35.,
+     qflux_width      = 16.,
+     warmpool_phase   = 140.,
+     warmpool_centr   = 0.,
+     gulf_k       = 4.0, 
+      gulf_amp     = 70., 
+     kuroshio_amp = 40.,
+     trop_atlantic_amp = 50.,
+     gulf_phase   = 310., 
+     Hawaiiextra = 30.0,
+      Pac_ITCZextra = -0.0,
+     north_sea_heat =0.0/
+# kuroshio_amp    = 50.,warmpool_amp     = 25., 
+
+ &damping_driver_nml
+     do_rayleigh   = .false.,
+     trayfric      = -0.5,
+     sponge_pbottom=  50.,
+     do_conserve_energy = .true.,
+     do_cg_drag    = .true., 
+     do_mg_drag = .false./
+
+&topography_nml
+	topog_file = 'INPUT/navy_topography.data.nc', 
+	water_file = 'INPUT/navy_pctwater.data.nc' /
+
+#Bn intiall 0, 5.4, 8.4 
+
+#flag            
+ &cg_drag_nml
+     Bt_0  = 0.0043,  
+     Bt_nh = 0.00,
+     Bt_eq = 0.0043,
+     Bt_sh = 0.00,
+     phi0n = 15.,
+     phi0s =-15.,
+     dphin = 10.,
+     dphis =-10.,
+     flag=0,
+     Bw = 0.4,
+     Bn = 0.0,
+     cw = 35.0,
+     cwtropics = 35.0,
+     cn =  2.0,
+    kelvin_kludge = 1.0,
+     weighttop = 0.7,
+     weightminus1 = 0.28,
+     weightminus2 = 0.02,
+     source_level_pressure = 315.e+02,
+     damp_level_pressure = 0.85e+02,
+     cg_drag_freq = 21600 /
+
+ &moist_processes_nml
+     do_bm           =.true.,   
+     do_bmmass       =.false., 
+     do_bmomp        =.false.,
+     do_mca          =.false.,
+     do_lsc          =.true.,
+     do_strat        =.false., 
+     do_ras          =.false.,
+     do_diag_clouds  =.false.,
+     do_rh_clouds    =.false.,
+     use_df_stuff = .true. /
+
+ &betts_miller_nml
+       tau_bm = 7200.,
+       rhbm   = .7   , 
+       do_simp = .false., 
+       do_shallower = .true., 
+       do_changeqref = .false.,
+       do_envsat = .false., 
+       do_taucape = .false., 
+       capetaubm = 900., 
+       tau_min = 2400./
+
+&moist_conv_nml
+       beta = 0.0,
+       use_df_stuff = .true./
+
+ &monin_obukhov_nml
+       rich_crit  = 2.0,
+       drag_min   = 4.e-05 /
+
+
+
+ &lscale_cond_nml
+       do_evap = .true.,
+       use_df_stuff = .true. /
+
+ &vert_diff_driver_nml
+        do_conserve_energy = .true.,
+	use_virtual_temp_vert_diff = .false. /
+
+
+
+ &diffusivity_nml
+     do_entrain = .false
+     use_df_stuff = .true. /
+
+ &surface_flux_nml
+     use_virtual_temp = .false.,
+     use_df_stuff = .true.,
+     old_dtaudv = .true.,
+     gust_const       =  1.0 /
+
+
+
+ &vert_turb_driver_nml
+    use_tau          = .false.,
+    gust_scheme      = 'constant',
+    constant_gust    = 0.,
+    do_mellor_yamada = .false.,
+    do_shallow_conv  = .false.,
+    use_df_stuff = .true., 
+    do_diffusivity = .true./
+
+ &ocean_rough_nml
+      rough_scheme = 'beljaars' /
+
+ &physics_driver_nml
+     do_grey_radiation = .false.,
+     do_rrtm_radiation = .true.,
+     do_damping = .true. /
+
+# domains_stack_size will vary for different model resolutions,
+# domain decompositions, and number of processors used.
+
+&fms_nml
+    domains_stack_size = 600000 /
+
+ &fms_io_nml
+    threading_write = 'single',
+    fileset_write = 'single' /
+
+
+
+

--- a/input/PTRBnamelist_Wave1_ZS0K_ZA12K_10days_45E.nml
+++ b/input/PTRBnamelist_Wave1_ZS0K_ZA12K_10days_45E.nml
@@ -1,0 +1,227 @@
+ &coupler_nml
+   days   = 150,
+   dt_atmos = 500,
+   current_date = 0001,1,1,0,0,0
+   calendar = 'thirty_day' /
+
+# Note: damping_order = 4 specifies del 8'th diffusion
+
+ &spectral_dynamics_nml
+    damping_option          = 'resolution_dependent',
+    damping_order           = 4,
+    do_mass_correction      =.true.,
+    do_energy_correction    =.true., 
+    do_water_correction     =.true.,  
+    water_correction_limit  = 200.e2,
+    initial_sphum           = 2.e-06,  
+    use_virtual_temperature =.false., 
+    vert_advect_uv          = 'second_centered',
+    vert_advect_t           = 'second_centered',
+    use_implicit            = .true.,
+    longitude_origin        = 0.,
+    robert_coeff            = .03,
+    alpha_implicit          = .5,
+    reference_sea_level_press=1.e5,
+    lon_max                 = 128,
+    lat_max                 = 64,
+    num_levels              = 40,
+    num_fourier             = 42,
+    num_spherical           = 43,
+    fourier_inc             = 1,
+    triang_trunc            =.true.,
+    topography_option       = 'interpolated',
+    ocean_topog_smoothing = 0.995,
+    vert_coord_option       = 'uneven_sigma',
+    surf_res                = 0.1,
+    scale_heights           = 7.9,
+    exponent                = 1.4,
+    do_stratoblob           =.true.,
+    scalefacZM              = 0.,
+    scalefacZA              = 12,
+    stratoblob_ZMorZA       = 'zonallyasymmetric',
+    kwn                     = 1,
+    phi0                    = 70,
+    dphi                    = -5,
+    phiZAlow                = 60,
+    phiZAhigh               = 80,
+    lonloc                  = 45,
+    plow                    = 60.e2,
+    ptrop                   = 150.e2,
+    remove_trough            = .true.,
+    TimeDuration             = 0,
+    TimeDurationZA           = 9 /
+
+# Empty namelist causes all values to take on default values.
+
+ &spectral_init_cont_nml
+    initial_temperature = 264. /
+
+---------- physics namelists --------------
+
+ &rrtm_radiation_nml
+     h2o_lower_limit        = 2.e-07,
+     co2ppmv                = 390.,
+     do_read_ozone          = .true.,
+     ozone_file             = 'ozone_1990',
+     dt_rad_avg             =  4500,
+     dt_rad                 =  4500,
+     lonstep                = 4 /
+
+ &astro_nml
+     solr_cnst   = 1370. /
+
+&simple_surface_nml
+     do_qflux         = .true.,
+     surface_choice   = 1,
+     Tm               = 285.,
+     heat_capacity    = 3.e08,
+     land_capacity    = 1.e07,
+     trop_capacity    = 1.e08,
+     trop_cap_limit   = 20.
+     const_albedo     = 0.23,
+     albedo_choice    = 7,
+     albedo_wdth      = 5,
+     higher_albedo    = 0.80,
+     albedo_cntrNH    =  68.,
+     albedo_cntrSH    =  64.,
+     lat_glacier      = -70,
+     land_option      = 'interpolated',
+     do_warmpool = .true.,
+     roughness_choice = 4,
+     mom_roughness_land = 5.e3,
+     q_roughness_land = 1.e-12  /   
+
+&qflux_nml
+     qflux_amp        = 26.,
+      warmpool_localization_choice = 3,
+     warmpool_k       = 1.66666, 
+     warmpool_amp     = 18., 
+     warmpool_width   = 35.,
+     qflux_width      = 16.,
+     warmpool_phase   = 140.,
+     warmpool_centr   = 0.,
+     gulf_k       = 4.0, 
+      gulf_amp     = 70., 
+     kuroshio_amp = 40.,
+     trop_atlantic_amp = 50.,
+     gulf_phase   = 310., 
+     Hawaiiextra = 30.0,
+      Pac_ITCZextra = -0.0,
+     north_sea_heat =0.0/
+
+ &damping_driver_nml
+     do_rayleigh   = .false.,
+     trayfric      = -0.5,
+     sponge_pbottom=  50.,
+     do_conserve_energy = .true.,
+     do_cg_drag    = .true., 
+     do_mg_drag = .false./
+
+&topography_nml
+	topog_file = 'INPUT/navy_topography.data.nc', 
+	water_file = 'INPUT/navy_pctwater.data.nc' /
+
+#Bn intiall 0, 5.4, 8.4 
+#flag            
+ &cg_drag_nml
+     Bt_0  = 0.0043,  
+     Bt_nh = 0.00,
+     Bt_eq = 0.0043,
+     Bt_sh = 0.00,
+     phi0n = 15.,
+     phi0s =-15.,
+     dphin = 10.,
+     dphis =-10.,
+     flag=0,
+     Bw = 0.4,
+     Bn = 0.0,
+     cw = 35.0,
+     cwtropics = 35.0,
+     cn =  2.0,
+    kelvin_kludge = 1.0,
+     weighttop = 0.7,
+     weightminus1 = 0.28,
+     weightminus2 = 0.02,
+     source_level_pressure = 315.e+02,
+     damp_level_pressure = 0.85e+02,
+     cg_drag_freq = 21600 /
+
+ 
+ &moist_processes_nml
+     do_bm           =.true.,   
+     do_bmmass       =.false., 
+     do_bmomp        =.false.,
+     do_mca          =.false.,
+     do_lsc          =.true.,
+     do_strat        =.false., 
+     do_ras          =.false.,
+     do_diag_clouds  =.false.,
+     do_rh_clouds    =.false.,
+     use_df_stuff = .true. /
+
+ &betts_miller_nml
+       tau_bm = 7200.,
+       rhbm   = .7   , 
+       do_simp = .false., 
+       do_shallower = .true., 
+       do_changeqref = .false.,
+       do_envsat = .false., 
+       do_taucape = .false., 
+       capetaubm = 900., 
+       tau_min = 2400./
+ 
+&moist_conv_nml
+       beta = 0.0,
+       use_df_stuff = .true./
+  
+ &monin_obukhov_nml
+       rich_crit  = 2.0,
+       drag_min   = 4.e-05 /
+
+ &lscale_cond_nml
+       do_evap = .true.,
+       use_df_stuff = .true. /
+
+ &vert_diff_driver_nml
+        do_conserve_energy = .true.,
+	use_virtual_temp_vert_diff = .false. /
+
+ &diffusivity_nml
+     do_entrain = .false
+     use_df_stuff = .true. /
+
+
+ &surface_flux_nml
+     use_virtual_temp = .false.,
+     use_df_stuff = .true.,
+     old_dtaudv = .true.,
+     gust_const       =  1.0 /
+
+ &vert_turb_driver_nml
+    use_tau          = .false.,
+    gust_scheme      = 'constant',
+    constant_gust    = 0.,
+    do_mellor_yamada = .false.,
+    do_shallow_conv  = .false.,
+    use_df_stuff = .true., 
+    do_diffusivity = .true./
+
+ &ocean_rough_nml
+      rough_scheme = 'beljaars' /
+
+ &physics_driver_nml
+     do_grey_radiation = .false.,
+     do_rrtm_radiation = .true.,
+     do_damping = .true. /
+
+# domains_stack_size will vary for different model resolutions,
+# domain decompositions, and number of processors used.
+
+&fms_nml
+    domains_stack_size = 600000 /
+
+ &fms_io_nml
+    threading_write = 'single',
+    fileset_write = 'single' /
+
+

--- a/input/PTRBnamelist_Wave1_ZS3K_10days_ZA6K_10days_45E.nml
+++ b/input/PTRBnamelist_Wave1_ZS3K_10days_ZA6K_10days_45E.nml
@@ -1,0 +1,227 @@
+ &coupler_nml
+   days   = 150,
+   dt_atmos = 500,
+   current_date = 0001,1,1,0,0,0
+   calendar = 'thirty_day' /
+
+# Note: damping_order = 4 specifies del 8'th diffusion
+
+ &spectral_dynamics_nml
+    damping_option          = 'resolution_dependent',
+    damping_order           = 4,
+    do_mass_correction      =.true.,
+    do_energy_correction    =.true., 
+    do_water_correction     =.true.,  
+    water_correction_limit  = 200.e2,
+    initial_sphum           = 2.e-06,  
+    use_virtual_temperature =.false., 
+    vert_advect_uv          = 'second_centered',
+    vert_advect_t           = 'second_centered',
+    use_implicit            = .true.,
+    longitude_origin        = 0.,
+    robert_coeff            = .03,
+    alpha_implicit          = .5,
+    reference_sea_level_press=1.e5,
+    lon_max                 = 128,
+    lat_max                 = 64,
+    num_levels              = 40,
+    num_fourier             = 42,
+    num_spherical           = 43,
+    fourier_inc             = 1,
+    triang_trunc            =.true.,
+    topography_option       = 'interpolated',
+    ocean_topog_smoothing = 0.995,
+    vert_coord_option       = 'uneven_sigma',
+    surf_res                = 0.1,
+    scale_heights           = 7.9,
+    exponent                = 1.4,
+    do_stratoblob           =.true.,
+    scalefacZM              = 3,
+    scalefacZA              = 6,
+    stratoblob_ZMorZA       = 'zonallyasymmetric',
+    kwn                     = 1,
+    phi0                    = 70,
+    dphi                    = -5,
+    phiZAlow                = 60,
+    phiZAhigh               = 80,
+    lonloc                  = 45,
+    plow                    = 60.e2,
+    ptrop                   = 150.e2,
+    remove_trough            = .true.,
+    TimeDuration             = 9,
+    TimeDurationZA           = 9 /
+
+# Empty namelist causes all values to take on default values.
+
+ &spectral_init_cont_nml
+    initial_temperature = 264. /
+
+---------- physics namelists --------------
+
+ &rrtm_radiation_nml
+     h2o_lower_limit        = 2.e-07,
+     co2ppmv                = 390.,
+     do_read_ozone          = .true.,
+     ozone_file             = 'ozone_1990',
+     dt_rad_avg             =  4500,
+     dt_rad                 =  4500,
+     lonstep                = 4 /
+
+ &astro_nml
+     solr_cnst   = 1370. /
+
+&simple_surface_nml
+     do_qflux         = .true.,
+     surface_choice   = 1,
+     Tm               = 285.,
+     heat_capacity    = 3.e08,
+     land_capacity    = 1.e07,
+     trop_capacity    = 1.e08,
+     trop_cap_limit   = 20.
+     const_albedo     = 0.23,
+     albedo_choice    = 7,
+     albedo_wdth      = 5,
+     higher_albedo    = 0.80,
+     albedo_cntrNH    =  68.,
+     albedo_cntrSH    =  64.,
+     lat_glacier      = -70,
+     land_option      = 'interpolated',
+     do_warmpool = .true.,
+     roughness_choice = 4,
+     mom_roughness_land = 5.e3,
+     q_roughness_land = 1.e-12  /   
+
+&qflux_nml
+     qflux_amp        = 26.,
+      warmpool_localization_choice = 3,
+     warmpool_k       = 1.66666, 
+     warmpool_amp     = 18., 
+     warmpool_width   = 35.,
+     qflux_width      = 16.,
+     warmpool_phase   = 140.,
+     warmpool_centr   = 0.,
+     gulf_k       = 4.0, 
+      gulf_amp     = 70., 
+     kuroshio_amp = 40.,
+     trop_atlantic_amp = 50.,
+     gulf_phase   = 310., 
+     Hawaiiextra = 30.0,
+      Pac_ITCZextra = -0.0,
+     north_sea_heat =0.0/
+
+ &damping_driver_nml
+     do_rayleigh   = .false.,
+     trayfric      = -0.5,
+     sponge_pbottom=  50.,
+     do_conserve_energy = .true.,
+     do_cg_drag    = .true., 
+     do_mg_drag = .false./
+
+&topography_nml
+	topog_file = 'INPUT/navy_topography.data.nc', 
+	water_file = 'INPUT/navy_pctwater.data.nc' /
+
+#Bn intiall 0, 5.4, 8.4 
+#flag            
+ &cg_drag_nml
+     Bt_0  = 0.0043,  
+     Bt_nh = 0.00,
+     Bt_eq = 0.0043,
+     Bt_sh = 0.00,
+     phi0n = 15.,
+     phi0s =-15.,
+     dphin = 10.,
+     dphis =-10.,
+     flag=0,
+     Bw = 0.4,
+     Bn = 0.0,
+     cw = 35.0,
+     cwtropics = 35.0,
+     cn =  2.0,
+    kelvin_kludge = 1.0,
+     weighttop = 0.7,
+     weightminus1 = 0.28,
+     weightminus2 = 0.02,
+     source_level_pressure = 315.e+02,
+     damp_level_pressure = 0.85e+02,
+     cg_drag_freq = 21600 /
+
+ 
+ &moist_processes_nml
+     do_bm           =.true.,   
+     do_bmmass       =.false., 
+     do_bmomp        =.false.,
+     do_mca          =.false.,
+     do_lsc          =.true.,
+     do_strat        =.false., 
+     do_ras          =.false.,
+     do_diag_clouds  =.false.,
+     do_rh_clouds    =.false.,
+     use_df_stuff = .true. /
+
+ &betts_miller_nml
+       tau_bm = 7200.,
+       rhbm   = .7   , 
+       do_simp = .false., 
+       do_shallower = .true., 
+       do_changeqref = .false.,
+       do_envsat = .false., 
+       do_taucape = .false., 
+       capetaubm = 900., 
+       tau_min = 2400./
+ 
+&moist_conv_nml
+       beta = 0.0,
+       use_df_stuff = .true./
+  
+ &monin_obukhov_nml
+       rich_crit  = 2.0,
+       drag_min   = 4.e-05 /
+
+ &lscale_cond_nml
+       do_evap = .true.,
+       use_df_stuff = .true. /
+
+ &vert_diff_driver_nml
+        do_conserve_energy = .true.,
+	use_virtual_temp_vert_diff = .false. /
+
+ &diffusivity_nml
+     do_entrain = .false
+     use_df_stuff = .true. /
+
+
+ &surface_flux_nml
+     use_virtual_temp = .false.,
+     use_df_stuff = .true.,
+     old_dtaudv = .true.,
+     gust_const       =  1.0 /
+
+ &vert_turb_driver_nml
+    use_tau          = .false.,
+    gust_scheme      = 'constant',
+    constant_gust    = 0.,
+    do_mellor_yamada = .false.,
+    do_shallow_conv  = .false.,
+    use_df_stuff = .true., 
+    do_diffusivity = .true./
+
+ &ocean_rough_nml
+      rough_scheme = 'beljaars' /
+
+ &physics_driver_nml
+     do_grey_radiation = .false.,
+     do_rrtm_radiation = .true.,
+     do_damping = .true. /
+
+# domains_stack_size will vary for different model resolutions,
+# domain decompositions, and number of processors used.
+
+&fms_nml
+    domains_stack_size = 600000 /
+
+ &fms_io_nml
+    threading_write = 'single',
+    fileset_write = 'single' /
+
+

--- a/input/diag_table
+++ b/input/diag_table
@@ -1,56 +1,269 @@
-"MiMA"
+spectral_rrtm
 0001 1 1 0 0 0
 #output files
-"atmos_daily",    24, "hours", 1, "days", "time",
-"atmos_davg",     24, "hours", 1, "days", "time",
-"atmos_dext",     24, "hours", 1, "days", "time",
-"atmos_avg",      -1, "hours", 1, "days", "time",
-#diagnostic field entries. 
-# quantities needed for plevel interpolation,
- "dynamics",        "bk",         "bk",             "atmos_daily",    "all", .false., "none", 2,
- "dynamics",        "pk",         "pk",             "atmos_daily",    "all", .false., "none", 2,
- "dynamics",        "ps",         "ps",             "atmos_daily",    "all", .false., "none", 2,
-# dynamics variables
- "dynamics",        "ucomp",      "ucomp",          "atmos_daily",    "all", .false., "none", 2,
- "dynamics",        "temp",       "temp",           "atmos_daily",    "all", .false., "none", 2,
- "dynamics",        "sphum",      "sphum",          "atmos_daily",    "all", .false., "none", 2,
- "dynamics",        "ucomp",      "ucomp",          "atmos_avg",      "all", .true.,  "none", 2,
- "dynamics",        "temp",       "temp",           "atmos_avg",      "all", .true.,  "none", 2,
- "dynamics",        "sphum",      "sphum",          "atmos_avg",      "all", .true.,  "none", 2,
-# surface variables
- "simple_surface",  "t_surf",     "t_surf",         "atmos_davg",     "all", .true., "none", 2,
- "simple_surface",  "t_surf",     "t_surf_max",     "atmos_dext",     "all", "max",  "none", 2,
- "simple_surface",  "t_surf",     "t_surf_min",     "atmos_dext",     "all", "min",  "none", 2,
-# moisture variables
-  "moist",          "precip",     "precip",         "atmos_davg",     "all", .true., "none", 2,
-  "moist",          "precip",     "precip_max",     "atmos_dext",     "all", "max",  "none", 2,
-#=============================================================================================
-#
-#  FORMATS FOR FILE ENTRIES (not all input values are used)
-#  ------------------------
-#
-#"file_name", output_freq, "output_units", format, "time_units", "long_name"
-#
-#
-#   output_freq:  > 0  output frequency in "output_units"
-#                 = 0  output frequency every time step
-#                 =-1  output frequency at end of run
-#
-#   output_units = units used for output frequency
-#                  (years, months, days, minutes, hours, seconds)
-#
-#   time_units   = units used to label the time axis
-#                  (days, minutes, hours, seconds)
-#
-#
-#  FORMAT FOR FIELD ENTRIES (not all input values are used)
-#  ------------------------
-#
-#"module_name", "field_name", "output_name", "file_name", "time_sampling", time_avg, "other_opts", packing
-#
-#   time_avg = .true. or .false.
-#
-#   packing  = 1  double precision
-#            = 2  float
-#            = 4  packed 16-bit integers
-#            = 8  packed 1-byte (not tested?)
+#"atmos_daily",    1, "days",  1, "seconds", "time",
+"atmos_daily_avg",      1, "days",  1, "seconds", "time",
+"atmos_4xdaily",        6, "hours", 1, "seconds", "time",
+"atmos_4xdaily_avg",    6, "hours", 1, "seconds", "time",
+"atmos_every",     0, "seconds", 1, "seconds", "time",
+#"atmos_avg",   -1, "days",  1, "days",    "time",
+
+
+"dynamics",    "forcingterm",   "forcingterm", "atmos_daily_avg", "all", .true., "none", 2,
+
+## Loading out dynamical tendencies
+#"dynamics",    "du_dt",   "du_dt", "atmos_daily_avg", "all", .true., "none", 2,
+#"dynamics",    "dv_dt",      "dv_dt",   "atmos_daily_avg", "all", .true., "none", 2,
+#"dynamics",    "dt_dt",      "dt_dt",   "atmos_daily_avg", "all", .true., "none", 2,
+#"dynamics",    "dln_ps_dt",  "dln_ps_dt", "atmos_daily_avg", "all", .true., "none", 2,
+
+
+#output variables - miscellaneous
+"dynamics",    "bk",      "bk",    "atmos_4xdaily", "all", .false., "none", 2,
+"dynamics",    "pk",      "pk",    "atmos_4xdaily", "all", .false., "none", 2,
+#"dynamics",    "zsurf",   "zsurf", "atmos_4xdaily", "all", .false., "none", 2,
+"dynamics",    "ps",      "ps",    "atmos_4xdaily", "all", .false., "none", 2,
+"dynamics",    "temp",    "temp",  "atmos_4xdaily", "all", .false., "none", 2,
+"dynamics",    "height",    "height",  "atmos_4xdaily", "all", .false., "none", 2,
+"dynamics",    "ucomp",   "ucomp", "atmos_4xdaily", "all", .false., "none", 2,
+"dynamics",    "vcomp",   "vcomp", "atmos_4xdaily", "all", .false., "none", 2,
+"dynamics",    "omega",   "omega", "atmos_4xdaily", "all", .false., "none", 2,
+
+"dynamics",    "sphum",   "sphum", "atmos_daily_avg", "all", .true., "none", 2,
+"dynamics",    "bk",      "bk",   "atmos_daily_avg", "all", .true., "none", 2,
+"dynamics",    "pk",      "pk",   "atmos_daily_avg", "all", .true., "none", 2,
+"dynamics",    "zsurf",  "zsurf", "atmos_daily_avg", "all", .true., "none", 2,
+"dynamics",    "tsurf",  "tsurf", "atmos_daily_avg", "all", .true., "none", 2,
+"dynamics",    "height",  "height", "atmos_daily_avg", "all", .true., "none", 2,
+"dynamics",    "ucomp",      "ucomp",   "atmos_daily_avg", "all", .true., "none", 2,
+"dynamics",    "vcomp",      "vcomp",   "atmos_daily_avg", "all", .true., "none", 2,
+"dynamics",    "temp",      "temp",   "atmos_daily_avg", "all", .true., "none", 2,
+"dynamics",    "omega",      "omega",   "atmos_daily_avg", "all", .true., "none", 2,
+"dynamics",  "div",         "div",         "atmos_daily_avg", "all", .true.,  "none", 2,
+"dynamics",  "vor",         "vor",         "atmos_daily_avg", "all", .true.,  "none", 2,
+"dynamics",    "ps",      "ps",   "atmos_daily_avg", "all", .true.,  "none", 2,
+"dynamics",    "slp",      "slp",   "atmos_daily_avg", "all", .true.,  "none", 2,
+"moist",        "rh",     "rh",   "atmos_daily_avg", "all", .true.,  "none", 2,
+"moist",     "precip",  "precip", "atmos_daily_avg", "all", .true.,  "none", 2,
+##"moist", "prec_conv", "prec_conv", "atmos_daily_avg", "all", .true., "none", 2,
+##"moist", "prec_ls",   "prec_ls",  "atmos_daily_avg", "all", .true.,  "none", 2,
+
+##--- Surface variables ---##
+## --- usurf, tsurf, zsurf are not the lowest atm level, but the surface variables 
+##"dynamics",    "usurf",   "usurf", "atmos_4xdaily", "all", .false., "none", 2,
+"simple_surface", "evap", "evap",     "atmos_daily_avg", "all", .true.,  "none", 2,
+#"simple_surface",  "oflx",  "oflx",   "atmos_daily_avg", "all", .true.,  "none", 2,
+#"simple_surface",  "albedo",  "albedo",   "atmos_daily_avg", "all", .true.,  "none", 2,
+"simple_surface",  "u_atm",  "u_atm",   "atmos_daily_avg", "all", .true.,  "none", 2,
+"simple_surface",  "v_atm",  "v_atm",   "atmos_daily_avg", "all", .true.,  "none", 2,
+"simple_surface", "t_surf", "t_surf", "atmos_daily_avg", "all", .true., "none", 2,
+"simple_surface", "shflx",   "shflx",       "atmos_daily_avg", "all", .true., "none", 2,
+# NB that u_surf does not work as the surface wind as register_diag_field in simple_surface.f90
+# is for u_atm (bottom level u). Further, in surface_flux.f90, u_surf is only an input and
+# not an output (hence cannot be outputted to file).
+#--------------------------------
+
+##------ Diabatic Heating Rate terms in TDEE (sensible heat, latent heat, longwave cooling, shortwave heating)
+"rrtm_radiation",  "tdt_lw",  "tdt_lw",  "atmos_daily_avg", "all", .true.,  "none", 2, 
+"rrtm_radiation",  "tdt_sw",  "tdt_sw",  "atmos_daily_avg", "all", .true.,  "none", 2,
+"vert_diff",  "tdt_vdif",    "tdt_vdif",    "atmos_daily_avg", "all", .true., "none", 2,
+"dynamics_every",   "tdt_dampuv",  "tdt_dampuv",  "atmos_daily_avg", "all", .true., "none", 2,
+"dynamics_every",   "tdt_tempcor", "tdt_tempcor", "atmos_daily_avg", "all", .true., "none", 2,
+"moist",  "tdt_ls",  "tdt_ls",  "atmos_daily_avg", "all", .true., "none", 2,
+"moist",  "tdt_conv", "tdt_conv", "atmos_daily_avg", "all", .true., "none", 2,
+##------
+
+#- GWD terms
+"damping", "udt_cgwd", "udt_cwgd","atmos_daily_avg", "all", .true., "none", 2,
+#"damping", "vdt_cgwd", "vdt_cwgd","atmos_daily_avg", "all", .true., "none", 2,
+
+
+# PV and calculated terms in every_step_diagnostics
+##"dynamics_every",    "pv",      "pv",   "atmos_daily_avg", "all", .true., "none", 2,
+##"dynamics_every",    "psi_dwc",      "psi_dwc",   "atmos_daily_avg", "all", .true., "none", 2,
+##"dynamics_every",    "upvp",      upvp",   "atmos_daily_avg", "all", .true., "none", 2,
+#"dynamics_every",   "vpTp",      "vpTp",           "atmos_4xdaily",    "all", .false., "none", 2,
+#"dynamics_every",   "pv",        "pv",             "atmos_4xdaily",    "all", .false., "none", 2,
+#"dynamics_every",   "pvCorrec",  "pvCorrec",       "atmos_4xdaily",    "all", .false., "none", 2,
+#"dynamics_every",   "pottemp",   "pottemp",         "atmos_4xdaily",    "all", .false., "none", 2,
+
+#------
+
+# --- Extra surface and moisture terms
+##"simple_surface", "heat_capacity",    "heat_capacity", "atmos_daily_avg", "all", .true., "none", 2,
+##"simple_surface",  "rough_mom",  "rough_mom",   "atmos_daily_avg", "all", .true.,  "none", 2,
+##"simple_surface",  "rough_moist",  "rough_moist",   "atmos_daily_avg", "all", .true.,  "none", 2,
+#"moist",       "precip",  "precip",   "atmos_4xdaily_avg", "all", .true.,  "none", 2,
+#"moist",  "prec_conv", "prec_conv",   "atmos_4xdaily_avg", "all", .true.,  "none", 2,
+#"moist",  "prec_ls",     "prec_ls",   "atmos_4xdaily_avg", "all", .true.,  "none", 2,
+
+# ------ u and dudt daily tendencies - 160220 
+##"dynamics",    "ucomp",      "ucomp",   "atmos_every", "all", .false., "none", 2,
+##"dynamics",    "dudt",      "dudt",   "atmos_every", "all", .false., "none", 2,
+##"dynamics_every",        "u_every",    "u_every",    "atmos_every", "all", .false., "none", 2,
+##"dynamics_every",        "udt_damp",    "udt_damp",    "atmos_every", "all", .false., "none", 2,
+#----- 160220
+
+
+#-----------------------------------------------------------------------------------------
+# "dynamics",    "bk",             "bk",             "atmos_daily",    "all", .false., "none", 2,
+# "dynamics",    "pk",             "pk",             "atmos_daily",    "all", .false., "none", 2,
+# "dynamics",    "zsurf",          "zsurf",          "atmos_daily",    "all", .false., "none", 2,
+# "dynamics",    "bk",             "bk",             "atmos_avg",    "all", .false., "none", 2,
+# "dynamics",    "pk",             "pk",             "atmos_avg",    "all", .false., "none", 2,
+# "dynamics",    "zsurf",          "zsurf",          "atmos_avg",    "all", .false., "none", 2,
+# "rrtm_radiation",  "tdt_rad",     "tdt_rad",     "atmos_avg",   "all", .true.,  "none", 2,
+# "rrtm_radiation",  "tdt_lw",      "tdt_lw",      "atmos_daily", "all", .false.,  "none", 2,
+# "rrtm_radiation",  "tdt_sw",      "tdt_sw",      "atmos_daily", "all", .false.,  "none", 2,
+# "rrtm_radiation",  "flux_sw",     "flux_sw",     "atmos_daily", "all", .false.,  "none", 2,
+# "rrtm_radiation",  "coszen",      "coszen",      "atmos_daily", "all", .false., "none", 2,
+# "rrtm_radiation",  "ozone",       "ozone",       "atmos_daily", "all", .false., "none", 2,
+# "rrtm_radiation",  "flux_lw",     "flux_lw",     "atmos_daily", "all", .false.,  "none", 2,
+# "rrtm_radiation",  "rrtm_albedo", "rrtm_albedo", "atmos_avg",   "all", .true.,   "none", 2,
+# "moist",        "rh",          "rh",          "atmos_daily", "all", .false.,  "none", 2,
+# "dynamics",        "sphum",       "sphum",       "atmos_daily", "all", .false.,  "none", 2,
+# "dynamics",  "vor",         "vor",         "atmos_daily", "all", .true.,  "none", 2,
+# "dynamics",  "div",         "div",         "atmos_daily", "all", .true.,  "none", 2,
+# "moist",     "tdt_ls",      "tdt_ls",      "atmos_daily", "all", .true., "none", 2,
+# "moist",     "precip",      "precip",      "atmos_daily", "all", .false.,  "none", 2,
+# "moist",     "prec_conv",   "prec_conv",   "atmos_daily", "all", .true.,  "none", 2,
+# "moist",     "prec_ls",     "prec_ls",     "atmos_daily", "all", .true.,  "none", 2,
+# "moist",     "cape",        "cape",        "atmos_daily", "all", .true.,  "none", 2,
+# "moist",     "cin",         "cin",         "atmos_daily", "all", .true.,  "none", 2,
+# "moist",     "bmflag",      "bmflag",      "atmos_daily", "all", .true., "none", 2,
+# "moist",     "klzbs",       "klzbs",       "atmos_daily", "all", .true., "none", 2,
+# "simple_surface",  "evap",  "evap",        "atmos_daily", "all", .true.,  "none", 2,
+# "simple_surface",  "t_surf", "t_surf",     "atmos_daily", "all", .false.,  "none", 2,
+# "simple_surface", "shflx",   "shflx",       "atmos_daily", "all", .true., "none", 2,
+# "dynamics",  "ps",          "ps",          "atmos_daily", "all", .true.,  "none", 2,
+# "dynamics",  "ps",          "ps",          "atmos_dailya", "all", .true.,  "none", 2,
+# "simple_surface", "u_star", "u_star",      "atmos_daily", "all", .true.,  "none", 2,
+# "simple_surface", "b_star", "b_star",      "atmos_daily", "all", .true.,  "none", 2,
+# "dynamics",  "ps",          "ps",          "atmos_daily", "all", .false.,  "none", 2,
+# "dynamics",  "ps",          "ps",          "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics",  "ucomp",       "ucomp",       "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics",  "vcomp",       "vcomp",       "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics",  "temp",        "temp",        "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics",  "sphum",       "sphum",       "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics",  "omega",       "omega",       "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics",  "omega",       "omega",       "atmos_daily", "all", .false.,  "none", 2,
+# "dynamics_every",  "dry_stat_en", "dry_stat_en", "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "moist_stat_en", "moist_stat_en", "atmos_avg", "all", .true., "none", 2,
+# "dynamics",  "div",         "div",         "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics",  "vor",         "vor",         "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics",  "wspd",        "wspd",        "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "uv",          "uv",          "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "vq",          "vq",          "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "vdse",        "vdse",        "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "vp",          "vp",          "atmos_avg", "all", .true.,  "none", 2, 
+# "dynamics_every",  "omegap",      "omegap",      "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "wdse",        "wdse",        "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "wq",          "wq",          "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "wv",          "wv",          "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "wu",          "wu",          "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "wdsep",       "wdsep",       "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "wqp",         "wqp",         "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "wvp",         "wvp",         "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "wup",         "wup",         "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "kegen",       "kegen",       "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "kegenq",      "kegenq",      "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "kegenqtinv",  "kegenqtinv",  "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "wsubt",       "wsubt",       "atmos_avg", "all", .true.,  "none", 2,
+# "dynamics_every",  "wsubtv",      "wsubtv",      "atmos_avg", "all", .true.,  "none", 2,
+# "moist",     "precip",      "precip",      "atmos_avg", "all", .true.,  "none", 2,
+#"moist",     "tref",        "tref",        "atmos_avg", "all", .true.,  "none", 2,
+#"moist",     "qref",        "qref",        "atmos_avg", "all", .true.,  "none", 2, 
+#"moist",     "prec_conv",   "prec_conv",   "atmos_avg", "all", .true.,  "none", 2,
+# "moist",     "prec_ls",     "prec_ls",     "atmos_avg", "all", .true.,  "none", 2,
+# "moist",     "rh",          "rh",          "atmos_avg", "all", .true.,  "none", 2,
+# "moist",     "cape",        "cape",        "atmos_avg", "all", .true.,  "none", 2,
+# "moist",     "cin",         "cin",         "atmos_avg", "all", .true.,  "none", 2,
+# "vert_turb", "z_pbl",       "z_pbl",       "atmos_avg", "all", .true.,  "none", 2,
+# "vert_turb", "diff_t",      "diff_t",      "atmos_avg", "all", .true.,  "none", 2,
+#"vert_turb", "tke",         "tke",         "atmos_avg", "all", .true.,  "none", 2,
+# "vert_turb", "diff_m",      "diff_m",      "atmos_avg", "all", .true.,  "none", 2,
+# "simple_surface",  "drag_heat",   "drag_heat",   "atmos_avg", "all", .true.,  "none", 2,
+# "vert_turb", "gust",       "gust",        "atmos_avg", "all", .true.,  "none", 2,
+# "simple_surface",  "t_surf",      "t_surf",      "atmos_avg", "all", .true.,  "none", 2,
+# "moist",           "rhsurf",      "rhsurf",      "atmos_avg", "all", .true.,  "none", 2,
+# "simple_surface",  "shflx",       "shflx",       "atmos_avg", "all", .true.,  "none", 2,
+# "simple_surface",  "evap",        "evap",        "atmos_avg", "all", .true.,  "none", 2,
+# "simple_surface",  "lwflx",       "lwflx",       "atmos_avg", "all", .true.,  "none", 2,
+# "simple_surface",  "wind",        "wind",        "atmos_avg", "all", .true.,  "none", 2,
+# "simple_surface",  "u_star",      "u_star",      "atmos_avg", "all", .true., "none", 2,
+# "simple_surface",  "b_star",      "b_star",      "atmos_avg", "all", .true., "none", 2,
+# "simple_surface",  "entrop_evap", "entrop_evap", "atmos_avg", "all", .true., "none", 2,
+# "simple_surface",  "entrop_shflx", "entrop_shflx", "atmos_avg", "all", .true., "none", 2,
+# "simple_surface",  "entrop_lwflx", "entrop_lwflx", "atmos_avg", "all", .true., "none", 2,
+# "rrtm_radiation",  "olr",         "olr",         "atmos_avg", "all", .true.,  "none", 2,
+# "rrtm_radiation",  "lwdn_sfc",    "lwdn_sfc",    "atmos_avg", "all", .true.,  "none", 2,
+# "rrtm_radiation",  "lwup_sfc",    "lwup_sfc",    "atmos_avg", "all", .true.,  "none", 2,
+# "rrtm_radiation",  "flux_rad",    "flux_rad",    "atmos_avg", "all", .true., "none", 2,
+# "rrtm_radiation",  "flux_lw",     "flux_lw",     "atmos_avg", "all", .true., "none", 2,
+# "rrtm_radiation",  "flux_sw",     "flux_sw",     "atmos_avg", "all", .true., "none", 2,
+# "vert_diff",       "tdt_vdif",    "tdt_vdif",    "atmos_avg", "all", .true., "none", 2,
+# "vert_diff",       "qdt_vdif",    "qdt_vdif",    "atmos_avg", "all", .true., "none", 2,
+# "vert_diff",       "udt_vdif",    "udt_vdif",    "atmos_avg", "all", .true., "none", 2,
+# "vert_diff",   "tdt_diss_vdif", "tdt_diss_vdif", "atmos_avg", "all", .true., "none", 2,
+# "vert_diff", "diss_heat_vdif", "diss_heat_vdif", "atmos_avg", "all", .true., "none", 2,
+# "vert_diff", "entrop_vdif_sens", "entrop_vdif_sens", "atmos_avg", "all", .true., "none", 2,
+# "vert_diff", "entrop_vdif_kediss", "entrop_vdif_kediss", "atmos_avg", "all", .true., "none", 2,
+# "damping",         "udt_rdamp",   "udt_rdamp",   "atmos_avg", "all", .true., "none", 2,
+# "moist",           "tdt_conv",    "tdt_conv",    "atmos_avg", "all", .true., "none", 2,
+# "moist",           "qdt_conv",    "qdt_conv",    "atmos_avg", "all", .true., "none", 2,
+# "moist",           "tdt_ls",      "tdt_ls",      "atmos_avg", "all", .true., "none", 2,
+# "moist",           "qdt_ls",      "qdt_ls",      "atmos_avg", "all", .true., "none", 2,
+# "moist",           "entrop_ls",   "entrop_ls",   "atmos_avg", "all", .true., "none", 2,
+###"dynamics_every",        "udt_damp",    "udt_damp",    "atmos_daily_avg", "all", .true., "none", 2,
+# "dynamics_every",        "vdt_damp",    "vdt_damp",    "atmos_avg", "all", .true., "none", 2,
+# "dynamics_every",        "tdt_damp",    "tdt_damp",    "atmos_avg", "all", .true., "none", 2,
+# "dynamics_every",    "entrop_dampuv", "entrop_dampuv", "atmos_avg", "all", .true., "none", 2,
+# "dynamics_every",      "entrop_dampt", "entrop_dampt", "atmos_avg", "all", .true., "none", 2,
+# "dynamics_every",        "tdt_dampuv",  "tdt_dampuv",  "atmos_avg", "all", .true., "none", 2,
+# "dynamics_every",        "tdt_tempcor", "tdt_tempcor", "atmos_avg", "all", .true., "none", 2,
+# "dynamics_every",      "qdt_watercor", "qdt_watercor", "atmos_avg", "all", .true., "none", 2,
+# "dynamics_every",  "entrop_tempcor", "entrop_tempcor", "atmos_avg", "all", .true., "none", 2,
+# "dynamics_every",        "sphum_hadv",    "sphum_hadv",    "atmos_avg", "all", .true., "none", 2,
+# "dynamics_every",        "sphum_vadv",    "sphum_vadv",    "atmos_avg", "all", .true., "none", 2,
+
+=============================================================================================
+
+====> This file can be used with diag_manager/v2.0a (or higher) <====
+
+
+  FORMATS FOR FILE ENTRIES (not all input values are used)
+  ------------------------
+
+"file_name", output_freq, "output_units", format, "time_units", "long_name",
+
+
+output_freq:  > 0  output frequency in "output_units"
+              = 0  output frequency every time step
+              =-1  output frequency at end of run
+
+output_units = units used for output frequency
+               (years, months, days, minutes, hours, seconds)
+
+time_units   = units used to label the time axis
+               (days, minutes, hours, seconds)
+
+
+  FORMAT FOR FIELD ENTRIES (not all input values are used)
+  ------------------------
+
+"module_name", "field_name", "output_name", "file_name" "time_sampling", time_avg, "other_opts", packing
+
+time_avg = .true. or .false.
+
+packing  = 1  double precision
+         = 2  float
+         = 4  packed 16-bit integers
+         = 8  packed 1-byte (not tested?)
+
+
+
+
+
+
+
+

--- a/src/atmos_spectral/tools/spherical_fourier.f90
+++ b/src/atmos_spectral/tools/spherical_fourier.f90
@@ -80,6 +80,9 @@ public :: compute_legendre, compute_gaussian
 integer :: fourier_max
 integer :: fourier_inc
 logical :: south_to_north_local
+logical :: make_zonallysymmetric_local
+logical :: do_truncate_local, truncatewave0 !IW: truncate waves
+integer :: truncatewave1, truncatewave2
 
 integer :: lat_max
 integer :: num_fourier
@@ -106,7 +109,7 @@ contains
 
 !-----------------------------------------------------------------------
 subroutine spherical_fourier_init(radius, lat_max_in, num_fourier_in, &
-                   fourier_inc_in, num_spherical_in, south_to_north)
+                   fourier_inc_in, num_spherical_in, south_to_north, make_zonallysymmetric,do_truncate,truncatewave1,truncatewave2,truncatewave0)
 !-----------------------------------------------------------------------
 
 real,    intent(in) :: radius
@@ -114,7 +117,8 @@ integer, intent(in) :: lat_max_in
 integer, intent(in) :: num_fourier_in
 integer, intent(in) :: fourier_inc_in
 integer, intent(in) :: num_spherical_in
-logical, intent(in), optional :: south_to_north
+logical, intent(in), optional :: south_to_north, make_zonallysymmetric, do_truncate, truncatewave0
+integer, intent(in), optional :: truncatewave1, truncatewave2
 
 call write_version_number(version, tagname)
 
@@ -122,6 +126,18 @@ if(present(south_to_north)) then
   south_to_north_local = south_to_north
 else
   south_to_north_local = .true.
+end if
+
+if(present(make_zonallysymmetric)) then ! IW: following ISCA
+  make_zonallysymmetric_local = make_zonallysymmetric
+else
+  make_zonallysymmetric_local = .false.
+end if
+
+if(present(do_truncate)) then ! IW: truncate waves
+  do_truncate_local = do_truncate
+else
+  do_truncate_local = .false.
 end if
 
 call get_grid_domain(is, ie, js, je)
@@ -134,7 +150,8 @@ num_spherical = num_spherical_in
 num_fourier   = num_fourier_in
 fourier_max   = num_fourier*fourier_inc
 
-call spherical_init(radius, num_fourier, fourier_inc, num_spherical)
+call spherical_init(radius, num_fourier, fourier_inc, num_spherical, make_zonallysymmetric=make_zonallysymmetric_local,&
+	do_truncate=do_truncate_local,truncatewave1=truncatewave1,truncatewave2=truncatewave2,truncatewave0=truncatewave0)
 call define_gaussian
 call define_legendre
 

--- a/src/atmos_spectral/tools/transforms.f90
+++ b/src/atmos_spectral/tools/transforms.f90
@@ -168,7 +168,11 @@ integer :: num_spherical=0
 
 logical :: south_to_north_local
 logical :: triang_trunc_local
+logical :: make_zonallysymmetric_local
 real :: longitude_origin_local
+
+logical :: do_truncate_local, truncatewave0
+integer :: truncatewave1, truncatewave2
 
 integer :: trunc_fourier
 logical :: module_is_initialized = .false.
@@ -196,7 +200,8 @@ subroutine transforms_init(radius,            &
                            num_spherical_in,  &
                            south_to_north,    &
                            triang_trunc,      &
-                           longitude_origin)
+                           longitude_origin,  &
+			   make_zonallysymmetric, do_truncate, truncatewave1, truncatewave2,truncatewave0)  !
 !---------------------------------------------------------------------------
 
 real,    intent(in) :: radius
@@ -206,9 +211,9 @@ integer, intent(in) :: num_fourier_in
 integer, intent(in) :: fourier_inc_in
 integer, intent(in) :: num_spherical_in
 
-logical, intent(in), optional :: south_to_north, triang_trunc
+logical, intent(in), optional :: south_to_north, triang_trunc, make_zonallysymmetric, do_truncate,truncatewave0
 real,    intent(in), optional :: longitude_origin
-integer :: namelist_unit, ierr, io
+integer :: namelist_unit, ierr, io, truncatewave1, truncatewave2
 
 real, allocatable :: wts_lat(:)
 real :: sum_wts, del_lon
@@ -243,6 +248,18 @@ else
   south_to_north_local = .true.
 end if
 
+if(present(make_zonallysymmetric)) then ! following ISCA
+  make_zonallysymmetric_local = make_zonallysymmetric
+else
+  make_zonallysymmetric_local = .false.
+end if
+
+if(present(do_truncate)) then ! IW: truncate wavenumbers
+  do_truncate_local = do_truncate
+else
+  do_truncate_local = .false.
+end if
+
 if(present(triang_trunc)) then
   triang_trunc_local = triang_trunc
 else
@@ -261,7 +278,9 @@ call get_spec_domain(ms, me, ns, ne)
    
 ! initialize spherical_fourier (which initializes spherical)
 call spherical_fourier_init(radius, lat_max, num_fourier, fourier_inc, num_spherical, &
-                            south_to_north=south_to_north_local)   
+                            south_to_north=south_to_north_local, make_zonallysymmetric=make_zonallysymmetric_local,&
+				do_truncate=do_truncate_local, truncatewave1=truncatewave1, &
+				   truncatewave2=truncatewave2,truncatewave0=truncatewave0)   
 
 trunc_fourier = num_fourier
 


### PR DESCRIPTION
Source code and example namelists for recreating the control run (CTRL) and perturbation heating experiments (PTRB) for a purely zonally-symmetric forcing  used in White et al. (2020; J. Climate), and the asymmetric and/or mixed symmetric-asymmetric forcing used in White et al. (2021; JGR-Atmospheres). Details of the namelist parameters present in the input namelist files can be found in the preamble to /src/atmos_spectral/model/spectral_dynamics.f90. 

Further minor changes to the source code in /atmos_spectral/ allow the user to specify the model to be run zonally-symmetric (i.e., only retain wave-0) or to truncate chosen zonal wavenumbers. Again, see the preamble to spectral_dynamics.f90 for details.